### PR TITLE
fix: disable react/display-name and react/no-bind

### DIFF
--- a/react.js
+++ b/react.js
@@ -5,7 +5,7 @@ module.exports = {
   },
   "rules": {
     "jsx-quotes": [2, "prefer-double"],
-    "react/display-name": 0,
+    "react/display-name": [1, { "ignoreTranspilerName": true }],
     "react/forbid-prop-types": 0,
     "react/no-danger": 2,
     "react/no-deprecated": [2, { "react": "15.0.0" }],

--- a/react.js
+++ b/react.js
@@ -5,7 +5,7 @@ module.exports = {
   },
   "rules": {
     "jsx-quotes": [2, "prefer-double"],
-    "react/display-name": [1, { "ignoreTranspilerName": true }],
+    "react/display-name": 0,
     "react/forbid-prop-types": 0,
     "react/no-danger": 2,
     "react/no-deprecated": [2, { "react": "15.0.0" }],
@@ -37,7 +37,7 @@ module.exports = {
     "react/jsx-indent-props": [2, 2],
     "react/jsx-key": 2,
     "react/jsx-max-props-per-line": [1, { "maximum": 3 }],
-    "react/jsx-no-bind": 2,
+    "react/jsx-no-bind": 0,
     "react/jsx-no-duplicate-props": 2,
     "react/jsx-no-literals": 0,
     "react/jsx-no-target-blank": 2,


### PR DESCRIPTION
React's refs string attributes are going to be deprecated and the new proposal is to use functions to set the element as a property of the component:

https://facebook.github.io/react/docs/more-about-refs.html

But it doesn't respect the `react/jsx-no-bind` rule so that's why I disabled it.

---

One more thing:

I made a wrong commit where I disabled the `react/display-name` rule but then I reenabled it because in case of components that are created by `React.createClass()` it's still useful when you'd like to debug them. However, it wouldn't be necessary to be set in case of pure functions since React can use the function's `name` property there so we have to live with this inconvenience until it'll be solved somehow by the contributors of `eslint-plugin-react`.
