### PR TITLE
Allow inline comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = {
     "no-implicit-coercion": 0,
     "no-implicit-globals": 2,
     "no-implied-eval": 2,
-    "no-inline-comments": 2,
+    "no-inline-comments": 0,
     "no-inner-declarations": [2, "both"],
     "no-invalid-regexp": 2,
     "no-invalid-this": 0,


### PR DESCRIPTION
I'd like to annotate objects, like

``` js
const foo = {
  bar: 1,
  baz: 'woof', // the default baz is woof beause of reasons
  qux: [4, 5, 6],
};
```

but obeying this rule takes up too much space (if i want to keep it readable):

``` js
const foo = {
  bar: 1,

  // the default baz is woof beause of reasons
  baz: 'woof',

  qux: [4, 5, 6],
};
```
