### PR TITLE
feat(index): throw error during fall-through

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = {
     "no-extra-label": 2,
     "no-extra-parens": 0,
     "no-extra-semi": 2,
-    "no-fallthrough": 0,
+    "no-fallthrough": 2,
     "no-floating-decimal": 0,
     "no-func-assign": 2,
     "no-implicit-coercion": 0,


### PR DESCRIPTION
Throw error when `break` or `// falls through` are not present in a `switch case`.

When you'd like to make it fall through on intention:
```js
switch(foo) {
    case 1:
        doSomething();
        // falls through

    case 2:
        doSomethingElse();
}

switch(foo) {
    case 1:
        doSomething();
        // fall through

    case 2:
        doSomethingElse();
}

switch(foo) {
    case 1:
        doSomething();
        // fallsthrough

    case 2:
        doSomethingElse();
}
```