### PR TITLE
chore: enable object curly spacing. --> error, always

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,7 +155,7 @@ module.exports = {
     "newline-before-return": 0,
     "newline-per-chained-call": 0,
     "object-curly-newline": 0,
-    "object-curly-spacing": 0,
+    "object-curly-spacing": [2, "always"],
     "object-property-newline": 0,
     "one-var": 0,
     "one-var-declaration-per-line": 0,


### PR DESCRIPTION
A year ago I disabled this rule because of @madbence.

@kristof0425 and I prefer putting spaces after opening curly brackets and before closing curly brackets. @oroce has told me that he's fine with it. @madbence was the only one who has never put spaces but he's not here anymore. 

I've changed this rule for the very last time. Deal with it.